### PR TITLE
adding argocd ci/cd

### DIFF
--- a/.gitea/workflows/build-push.yaml
+++ b/.gitea/workflows/build-push.yaml
@@ -1,0 +1,67 @@
+name: Docker Image Container Build and Push
+on: [push]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    container:
+      image: catthehacker/ubuntu:act-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Increment version
+        id: version
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const url = `https://gitea.armstronglabs.net/api/v1/packages/bill?access_token=${{ secrets.TOKEN }}`;
+
+            const response = await fetch(url);
+            const data = await response.json();
+
+            const tags = data.filter(tag => !tag.version.startsWith('sha'));
+
+            const version_tags = tags.map(tag => tag.version).filter(tag => tag !== 'latest').sort().reverse();
+
+            console.log('Version tags:', version_tags);
+
+            const latest_version = version_tags[0];
+
+            console.log('Last version:', latest_version);
+
+            const version_parts = latest_version.split('.');
+            const patch_version = parseInt(version_parts[2]) + 1;
+            const new_version = `${version_parts[0]}.${version_parts[1]}.${patch_version}`;
+
+            console.log('New version:', new_version);
+
+            return new_version;
+          result-encoding: string
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Gitea Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: gitea.armstronglabs.net
+          username: ${{ secrets.PUSH_USERNAME }}
+          password: ${{ secrets.PUSH_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: . 
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            gitea.armstronglabs.net/bill/uploadServer:latest
+            gitea.armstronglabs.net/bill/uploadServer:${{ steps.version.outputs.result }}
+            
+      - name: Inspect 
+        run: |
+          docker buildx imagetools inspect gitea.armstronglabs.net/bill/uploadServer:latest
+          docker buildx imagetools inspect gitea.armstronglabs.net/bill/uploadServer:${{ steps.version.outputs.result }}

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -1,0 +1,67 @@
+name: Docker Image Container Build and Push
+on: [push]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    container:
+      image: catthehacker/ubuntu:act-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Increment version
+        id: version
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const url = `https://registry.hub.docker.com/v2/repositories/explosion33/upload-server/tags`;
+
+            const response = await fetch(url);
+            const data = await response.json();
+
+            const tags = data.results.map(result => result.name).filter(tag => !tag.startsWith('sha'));
+
+            const version_tags = tags.filter(tag => tag !== 'latest').sort().reverse();
+
+            console.log('Version tags:', version_tags);
+
+            const latest_version = version_tags[0];
+
+            console.log('Last version:', latest_version);
+
+            const version_parts = latest_version.split('.');
+            const patch_version = parseInt(version_parts[2]) + 1;
+            const new_version = `${version_parts[0]}.${version_parts[1]}.${patch_version}`;
+
+            console.log('New version:', new_version);
+
+            return new_version;
+          result-encoding: string
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: . 
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            explosion33/upload-server:latest
+            explosion33/upload-server:${{ steps.version.outputs.result }}
+            
+      - name: Inspect 
+        run: |
+          docker buildx imagetools inspect explosion33/upload-server:latest
+          docker buildx imagetools inspect explosion33/upload-server:${{ steps.version.outputs.result }}

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: arbitrary
+
+resources:
+  - manifests/upload-server-deployment.yaml
+  - manifests/upload-server-nodeport.yaml

--- a/manifests/upload-server-deployment.yaml
+++ b/manifests/upload-server-deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: upload-server-app
+  name: upload-server-app
+  namespace: ethan
+spec:
+  replicas: 1
+  template:
+    metadata:
+      name: upload-server-app
+      labels:
+        app:  upload-server-app
+    spec:
+      containers:
+      - name: upload-server-app
+        image: explosion33/upload-server:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 5000
+
+  selector:
+    matchLabels:
+      app: upload-server-app

--- a/manifests/upload-server-nodeport.yaml
+++ b/manifests/upload-server-nodeport.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: upload-server-app
+  name: upload-server-app
+  namespace: ethan
+spec:
+  ports:
+  - nodePort: 30500
+    port: 5000
+    protocol: TCP
+    targetPort: 5000
+    name: html
+
+  selector:
+    app: upload-server-app
+  type: NodePort


### PR DESCRIPTION
Ethan - this is to migrate from the Keel web-hook to the Argo ci/cd environment.  After you accept this pull request I'll add the applications to the argocd CI server and then also add the repository to argocd-image-updater.

Consider changing to a `semver` tagging for the docker images.  If you migrate the repository to the gitea servers you can manage them from there.  The gitea servers have action runners already setup for the build pipeline.  If you want to stay on github, you'll need to add a gitaction for the build side.